### PR TITLE
Spm support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             exclude: [
                 "JTSImageViewController-Prefix.pch",
                 "JTSImageViewController-Info.plist"
-            ].
+            ],
             publicHeadersPath: ""
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "JTSImageViewController",
+    platforms: [.iOS(.v12)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "JTSImageViewController",
+            targets: ["JTSImageViewController"]),
+    ],
+    targets: [
+        .target(
+            name: "JTSImageViewController",
+            path: "Source",
+            exclude: [
+                "JTSImageViewController-Prefix.pch",
+                "JTSImageViewController-Info.plist"
+            ].
+            publicHeadersPath: ""
+        ),
+    ]
+)

--- a/Source/JTSImageInfo.h
+++ b/Source/JTSImageInfo.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Nice Boy LLC. All rights reserved.
 //
 
-@import Foundation;
+@import UIKit;
 
 @interface JTSImageInfo : NSObject
 

--- a/Source/JTSSimpleImageDownloader.h
+++ b/Source/JTSSimpleImageDownloader.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Nice Boy LLC. All rights reserved.
 //
 
-@import Foundation;
+@import UIKit;
 
 @interface JTSSimpleImageDownloader : NSObject
 


### PR DESCRIPTION
Follows spm branch of https://github.com/jonbrooks/JTSImageViewController/, without the generated xcodeproj.  Package manifest opens in Xcode, generate-xcodeproj deprecated as of Xcode 12.5.